### PR TITLE
Fixed the signup bug

### DIFF
--- a/todo/lib/application/auth/singupfrom/signupform_bloc.dart
+++ b/todo/lib/application/auth/singupfrom/signupform_bloc.dart
@@ -16,7 +16,11 @@ class SignupformBloc extends Bloc<SignupformEvent, SignupformState> {
             authFailureOrSuccessOption: none())) {
     on<RegisterWithEmailAndPasswordPressed>((event, emit) async {
       if (event.email == null || event.password == null) {
-        emit(state.copyWith(isSubmitting: false, showValidationMessages: true));
+        emit(state.copyWith(
+          isSubmitting: false,
+          showValidationMessages: true,
+          authFailureOrSuccessOption: none(),
+        ));
       } else {
         emit(state.copyWith(isSubmitting: true, showValidationMessages: false));
         final failureOrSuccess =
@@ -31,7 +35,11 @@ class SignupformBloc extends Bloc<SignupformEvent, SignupformState> {
 
     on<SignInWithEmailAndPasswordPressed>((event, emit) async {
       if (event.email == null || event.password == null) {
-        emit(state.copyWith(isSubmitting: false, showValidationMessages: true));
+        emit(state.copyWith(
+          isSubmitting: false,
+          showValidationMessages: true,
+          authFailureOrSuccessOption: none(),
+        ));
       } else {
         emit(state.copyWith(isSubmitting: true, showValidationMessages: false));
         final failureOrSuccess =

--- a/todo_redesign/lib/application/auth/singupfrom/signupform_bloc.dart
+++ b/todo_redesign/lib/application/auth/singupfrom/signupform_bloc.dart
@@ -18,7 +18,11 @@ class SignupformBloc extends Bloc<SignupformEvent, SignupformState> {
       if (event.email == null || event.password == null) {
         emit(state.copyWith(isSubmitting: false, showValidationMessages: true));
       } else {
-        emit(state.copyWith(isSubmitting: true, showValidationMessages: false));
+        emit(state.copyWith(
+          isSubmitting: true,
+          showValidationMessages: false,
+          authFailureOrSuccessOption: none(),
+        ));
         final failureOrSuccess =
             await authRepository.registerWithEmailAndPassword(
                 email: event.email!, password: event.password!);
@@ -33,7 +37,11 @@ class SignupformBloc extends Bloc<SignupformEvent, SignupformState> {
       if (event.email == null || event.password == null) {
         emit(state.copyWith(isSubmitting: false, showValidationMessages: true));
       } else {
-        emit(state.copyWith(isSubmitting: true, showValidationMessages: false));
+        emit(state.copyWith(
+          isSubmitting: true,
+          showValidationMessages: false,
+          authFailureOrSuccessOption: none(),
+        ));
         final failureOrSuccess =
             await authRepository.signInWithEmailAndPassword(
                 email: event.email!, password: event.password!);


### PR DESCRIPTION
Wenn man versucht, sich mit falschen Daten in der Todo App einzuloggen, kommt die entsprechende Fehlermeldung. Wenn man beim zweiten mal Register drückt oder sich mit korrekten Daten einloggt, kommt die Fehlermeldung fälschlicherweise erneut, da der Error State aus dem ersten Mal erhalten bleibt. 